### PR TITLE
Upgraded dependencies

### DIFF
--- a/LEGAL.txt
+++ b/LEGAL.txt
@@ -1,24 +1,30 @@
 Dependency: 
   name: @babel/code-frame
-  version: 7.5.5
+  version: 7.8.3
   repository: https://github.com/babel/babel/tree/master/packages/babel-code-frame
   licenses: MIT
 
 Dependency: 
+  name: @babel/helper-validator-identifier
+  version: 7.9.0
+  repository: https://github.com/babel/babel/tree/master/packages/babel-helper-validator-identifier
+  licenses: MIT
+
+Dependency: 
   name: @babel/highlight
-  version: 7.5.0
+  version: 7.9.0
   repository: https://github.com/babel/babel/tree/master/packages/babel-highlight
   licenses: MIT
 
 Dependency: 
   name: @ephox/swag
-  version: 4.1.5
+  version: 4.2.1
   repository: https://github.com/ephox/swag
   licenses: Apache-2.0
 
 Dependency: 
   name: @ephox/tslint-rules
-  version: 1.0.11
+  version: 1.1.1
   repository: (none)
   licenses: Apache-2.0
 
@@ -30,7 +36,7 @@ Dependency:
 
 Dependency: 
   name: @types/chai
-  version: 4.2.3
+  version: 4.2.11
   repository: https://github.com/DefinitelyTyped/DefinitelyTyped
   licenses: MIT
 
@@ -53,6 +59,12 @@ Dependency:
   licenses: MIT
 
 Dependency: 
+  name: @types/estree
+  version: 0.0.44
+  repository: (none)
+  licenses: MIT
+
+Dependency: 
   name: @types/grunt
   version: 0.4.25
   repository: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -66,19 +78,19 @@ Dependency:
 
 Dependency: 
   name: @types/node
-  version: 11.10.5
-  repository: (none)
-  licenses: MIT
-
-Dependency: 
-  name: @types/node
-  version: 12.7.11
+  version: 12.12.34
   repository: https://github.com/DefinitelyTyped/DefinitelyTyped
   licenses: MIT
 
 Dependency: 
+  name: @types/node
+  version: 13.11.0
+  repository: (none)
+  licenses: MIT
+
+Dependency: 
   name: acorn
-  version: 7.1.0
+  version: 7.1.1
   repository: https://github.com/acornjs/acorn
   licenses: MIT
 
@@ -126,7 +138,7 @@ Dependency:
 
 Dependency: 
   name: arg
-  version: 4.1.1
+  version: 4.1.3
   repository: zeit/arg
   licenses: MIT
 
@@ -222,7 +234,7 @@ Dependency:
 
 Dependency: 
   name: chokidar
-  version: 3.2.1
+  version: 3.3.1
   repository: https://github.com/paulmillr/chokidar
   licenses: MIT
 
@@ -257,6 +269,12 @@ Dependency:
   licenses: MIT
 
 Dependency: 
+  name: commander
+  version: 2.20.3
+  repository: (none)
+  licenses: MIT
+
+Dependency: 
   name: compare-versions
   version: 3.4.0
   repository: https://github.com/omichelsen/compare-versions
@@ -270,14 +288,8 @@ Dependency:
 
 Dependency: 
   name: debug
-  version: 3.1.0
-  repository: http://github.com/visionmedia/debug
-  licenses: MIT
-
-Dependency: 
-  name: debug
   version: 3.2.6
-  repository: (none)
+  repository: http://github.com/visionmedia/debug
   licenses: MIT
 
 Dependency: 
@@ -312,7 +324,7 @@ Dependency:
 
 Dependency: 
   name: diff
-  version: 4.0.1
+  version: 4.0.2
   repository: http://github.com/kpdecker/jsdiff
   licenses: BSD-3-Clause
 
@@ -324,13 +336,13 @@ Dependency:
 
 Dependency: 
   name: es-abstract
-  version: 1.15.0
+  version: 1.17.5
   repository: http://github.com/ljharb/es-abstract
   licenses: MIT
 
 Dependency: 
   name: es-to-primitive
-  version: 1.2.0
+  version: 1.2.1
   repository: http://github.com/ljharb/es-to-primitive
   licenses: MIT
 
@@ -342,33 +354,27 @@ Dependency:
 
 Dependency: 
   name: escodegen
-  version: 1.12.0
+  version: 1.14.1
   repository: http://github.com/estools/escodegen
   licenses: BSD-2-Clause
 
 Dependency: 
   name: esprima
-  version: 3.1.3
+  version: 4.0.1
   repository: https://github.com/jquery/esprima
   licenses: BSD-2-Clause
 
 Dependency: 
-  name: esprima
-  version: 4.0.1
-  repository: (none)
-  licenses: BSD-2-Clause
-
-Dependency: 
   name: estraverse
-  version: 4.2.0
+  version: 4.3.0
   repository: http://github.com/estools/estraverse
   licenses: BSD-2-Clause
 
 Dependency: 
   name: esutils
-  version: 2.0.2
+  version: 2.0.3
   repository: http://github.com/estools/esutils
-  licenses: BSD, BSD
+  licenses: BSD-2-Clause
 
 Dependency: 
   name: fast-levenshtein
@@ -407,6 +413,12 @@ Dependency:
   licenses: ISC
 
 Dependency: 
+  name: fsevents
+  version: 2.1.2
+  repository: https://github.com/fsevents/fsevents
+  licenses: MIT
+
+Dependency: 
   name: function-bind
   version: 1.1.1
   repository: http://github.com/Raynos/function-bind
@@ -426,13 +438,13 @@ Dependency:
 
 Dependency: 
   name: glob
-  version: 7.1.2
+  version: 7.1.3
   repository: (none)
   licenses: ISC
 
 Dependency: 
   name: glob
-  version: 7.1.3
+  version: 7.1.6
   repository: http://github.com/isaacs/node-glob
   licenses: ISC
 
@@ -444,7 +456,7 @@ Dependency:
 
 Dependency: 
   name: glob-parent
-  version: 5.1.0
+  version: 5.1.1
   repository: gulpjs/glob-parent
   licenses: ISC
 
@@ -468,7 +480,7 @@ Dependency:
 
 Dependency: 
   name: has-symbols
-  version: 1.0.0
+  version: 1.0.1
   repository: http://github.com/ljharb/has-symbols
   licenses: MIT
 
@@ -480,7 +492,7 @@ Dependency:
 
 Dependency: 
   name: hosted-git-info
-  version: 2.7.1
+  version: 2.8.8
   repository: https://github.com/npm/hosted-git-info
   licenses: ISC
 
@@ -492,7 +504,7 @@ Dependency:
 
 Dependency: 
   name: inherits
-  version: 2.0.3
+  version: 2.0.4
   repository: http://github.com/isaacs/inherits
   licenses: ISC
 
@@ -510,13 +522,13 @@ Dependency:
 
 Dependency: 
   name: is-callable
-  version: 1.1.4
+  version: 1.1.5
   repository: http://github.com/ljharb/is-callable
   licenses: MIT
 
 Dependency: 
   name: is-date-object
-  version: 1.0.1
+  version: 1.0.2
   repository: http://github.com/ljharb/is-date-object
   licenses: MIT
 
@@ -546,14 +558,14 @@ Dependency:
 
 Dependency: 
   name: is-regex
-  version: 1.0.4
+  version: 1.0.5
   repository: http://github.com/ljharb/is-regex
   licenses: MIT
 
 Dependency: 
   name: is-symbol
-  version: 1.0.2
-  repository: http://github.com/ljharb/is-symbol
+  version: 1.0.3
+  repository: http://github.com/inspect-js/is-symbol
   licenses: MIT
 
 Dependency: 
@@ -654,13 +666,13 @@ Dependency:
 
 Dependency: 
   name: magic-string
-  version: 0.25.4
+  version: 0.25.7
   repository: https://github.com/rich-harris/magic-string
   licenses: MIT
 
 Dependency: 
   name: make-error
-  version: 1.3.0
+  version: 1.3.6
   repository: http://github.com/JsCommunity/make-error
   licenses: ISC
 
@@ -672,38 +684,38 @@ Dependency:
 
 Dependency: 
   name: minimist
-  version: 0.0.8
-  repository: http://github.com/substack/minimist
-  licenses: MIT
-
-Dependency: 
-  name: minimist
   version: 0.1.0
   repository: (none)
   licenses: MIT
 
 Dependency: 
+  name: minimist
+  version: 1.2.5
+  repository: http://github.com/substack/minimist
+  licenses: MIT
+
+Dependency: 
   name: mkdirp
-  version: 0.5.1
+  version: 0.5.4
   repository: https://github.com/substack/node-mkdirp
   licenses: MIT
 
 Dependency: 
+  name: mkdirp
+  version: 0.5.5
+  repository: (none)
+  licenses: MIT
+
+Dependency: 
   name: mocha
-  version: 6.2.1
+  version: 6.2.3
   repository: https://github.com/mochajs/mocha
   licenses: MIT
 
 Dependency: 
   name: ms
-  version: 2.0.0
-  repository: zeit/ms
-  licenses: MIT
-
-Dependency: 
-  name: ms
   version: 2.1.1
-  repository: (none)
+  repository: zeit/ms
   licenses: MIT
 
 Dependency: 
@@ -732,7 +744,7 @@ Dependency:
 
 Dependency: 
   name: object-inspect
-  version: 1.6.0
+  version: 1.7.0
   repository: http://github.com/substack/object-inspect
   licenses: MIT
 
@@ -750,8 +762,8 @@ Dependency:
 
 Dependency: 
   name: object.getownpropertydescriptors
-  version: 2.0.3
-  repository: http://github.com/ljharb/object.getownpropertydescriptors
+  version: 2.1.0
+  repository: http://github.com/es-shims/object.getownpropertydescriptors
   licenses: MIT
 
 Dependency: 
@@ -762,13 +774,13 @@ Dependency:
 
 Dependency: 
   name: optionator
-  version: 0.8.2
+  version: 0.8.3
   repository: http://github.com/gkz/optionator
   licenses: MIT
 
 Dependency: 
   name: p-limit
-  version: 2.2.1
+  version: 2.2.2
   repository: sindresorhus/p-limit
   licenses: MIT
 
@@ -810,7 +822,7 @@ Dependency:
 
 Dependency: 
   name: picomatch
-  version: 2.0.7
+  version: 2.2.2
   repository: micromatch/picomatch
   licenses: MIT
 
@@ -834,7 +846,7 @@ Dependency:
 
 Dependency: 
   name: readdirp
-  version: 3.1.3
+  version: 3.3.0
   repository: http://github.com/paulmillr/readdirp
   licenses: MIT
 
@@ -852,21 +864,15 @@ Dependency:
 
 Dependency: 
   name: resolve
-  version: 1.10.0
+  version: 1.15.1
   repository: http://github.com/browserify/resolve
   licenses: MIT
 
 Dependency: 
   name: rollup
-  version: 1.22.0
+  version: 1.32.1
   repository: rollup/rollup
   licenses: MIT
-
-Dependency: 
-  name: semver
-  version: 5.6.0
-  repository: (none)
-  licenses: ISC
 
 Dependency: 
   name: semver
@@ -924,13 +930,13 @@ Dependency:
 
 Dependency: 
   name: source-map-support
-  version: 0.5.13
+  version: 0.5.16
   repository: https://github.com/evanw/node-source-map-support
   licenses: MIT
 
 Dependency: 
   name: sourcemap-codec
-  version: 1.4.6
+  version: 1.4.8
   repository: https://github.com/Rich-Harris/sourcemap-codec
   licenses: MIT
 
@@ -953,15 +959,27 @@ Dependency:
   licenses: MIT
 
 Dependency: 
+  name: string.prototype.trimend
+  version: 1.0.0
+  repository: (none)
+  licenses: MIT
+
+Dependency: 
   name: string.prototype.trimleft
-  version: 2.1.0
+  version: 2.1.2
   repository: http://github.com/es-shims/String.prototype.trimLeft
   licenses: MIT
 
 Dependency: 
   name: string.prototype.trimright
-  version: 2.1.0
+  version: 2.1.2
   repository: http://github.com/es-shims/String.prototype.trimRight
+  licenses: MIT
+
+Dependency: 
+  name: string.prototype.trimstart
+  version: 1.0.0
+  repository: (none)
   licenses: MIT
 
 Dependency: 
@@ -1008,19 +1026,19 @@ Dependency:
 
 Dependency: 
   name: ts-node
-  version: 8.4.1
+  version: 8.8.2
   repository: http://github.com/TypeStrong/ts-node
   licenses: MIT
 
 Dependency: 
   name: tslib
-  version: 1.9.3
+  version: 1.11.1
   repository: https://github.com/Microsoft/tslib
   licenses: Apache-2.0
 
 Dependency: 
   name: tslint
-  version: 5.20.0
+  version: 5.20.1
   repository: https://github.com/palantir/tslint
   licenses: Apache-2.0
 
@@ -1044,7 +1062,7 @@ Dependency:
 
 Dependency: 
   name: typescript
-  version: 3.6.3
+  version: 3.8.3
   repository: https://github.com/Microsoft/TypeScript
   licenses: Apache-2.0
 
@@ -1079,9 +1097,9 @@ Dependency:
   licenses: ISC
 
 Dependency: 
-  name: wordwrap
-  version: 1.0.0
-  repository: http://github.com/substack/node-wordwrap
+  name: word-wrap
+  version: 1.2.3
+  repository: jonschlinkert/word-wrap
   licenses: MIT
 
 Dependency: 
@@ -1116,13 +1134,13 @@ Dependency:
 
 Dependency: 
   name: yargs
-  version: 13.3.0
+  version: 13.3.2
   repository: https://github.com/yargs/yargs
   licenses: MIT
 
 Dependency: 
   name: yargs-parser
-  version: 13.1.1
+  version: 13.1.2
   repository: git@github.com:yargs/yargs-parser
   licenses: ISC
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,13 +9,18 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
+"@babel/helper-validator-identifier@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
+  integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
+
 "@babel/highlight@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.8.3.tgz#28f173d04223eaaa59bc1d439a3836e6d1265797"
-  integrity sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
+  integrity sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
   dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
     chalk "^2.0.0"
-    esutils "^2.0.2"
     js-tokens "^4.0.0"
 
 "@ephox/tslint-rules@^1.0.11":
@@ -48,9 +53,9 @@
   integrity sha1-UjCpznluBCzabwhtvxnyLqMwZZw=
 
 "@types/estree@*":
-  version "0.0.42"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.42.tgz#8d0c1f480339efedb3e46070e22dd63e0430dd11"
-  integrity sha512-K1DPVvnBCPxzD+G51/cxVIoc2X8uUVl1zpJeE6iKcgHMj4+tbat5Xu4TjV7v2QSDbIeAfLi2hIk+u2+s0MlpUQ==
+  version "0.0.44"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.44.tgz#980cc5a29a3ef3bea6ff1f7d021047d7ea575e21"
+  integrity sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g==
 
 "@types/estree@0.0.39":
   version "0.0.39"
@@ -70,14 +75,14 @@
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
 "@types/node@*":
-  version "13.9.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.1.tgz#96f606f8cd67fb018847d9b61e93997dabdefc72"
-  integrity sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==
+  version "13.11.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.0.tgz#390ea202539c61c8fa6ba4428b57e05bc36dc47b"
+  integrity sha512-uM4mnmsIIPK/yeO+42F2RQhGUIs39K2RFmugcJANppXe6J1nvH87PvzPZYpza7Xhhs8Yn9yIAVdLZ84z61+0xQ==
 
 "@types/node@^12.7.11":
-  version "12.12.30"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.30.tgz#3501e6f09b954de9c404671cefdbcc5d9d7c45f6"
-  integrity sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg==
+  version "12.12.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.34.tgz#0a5d6ae5d22612f0cf5f10320e1fc5d2a745dcb8"
+  integrity sha512-BneGN0J9ke24lBRn44hVHNeDlrXRYF+VRp0HbSUNnEZahXGAysHZIqnf/hER6aabdBgzM4YOV4jrR8gj4Zfi0g==
 
 acorn@^7.1.0:
   version "7.1.1"
@@ -223,9 +228,9 @@ check-error@^1.0.2:
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 chokidar@*:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.2.1.tgz#4634772a1924512d990d4505957bf3a510611387"
-  integrity sha512-/j5PPkb5Feyps9e+jo07jUZGvkB5Aj953NrI4s8xSVScrAo/RHeILrtdb4uzR7N6aaFFxxJ+gt8mA8HfNpw76w==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
+  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
   dependencies:
     anymatch "~3.1.1"
     braces "~3.0.2"
@@ -233,9 +238,9 @@ chokidar@*:
     is-binary-path "~2.1.0"
     is-glob "~4.0.1"
     normalize-path "~3.0.0"
-    readdirp "~3.1.3"
+    readdirp "~3.3.0"
   optionalDependencies:
-    fsevents "~2.1.0"
+    fsevents "~2.1.2"
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -288,19 +293,12 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-debug@3.2.6, debug@^3.2.5:
+debug@3.2.6, debug@^3.1.0, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -341,10 +339,10 @@ emoji-regex@^7.0.1:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
-es-abstract@^1.17.0-next.1:
-  version "1.17.4"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
-  integrity sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
+es-abstract@^1.17.0-next.1, es-abstract@^1.17.5:
+  version "1.17.5"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.5.tgz#d8c9d1d66c8981fb9200e2251d799eee92774ae9"
+  integrity sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==
   dependencies:
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
@@ -437,10 +435,10 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.0.tgz#ce1a5f9ac71c6d75278b0c5bd236d7dfece4cbaa"
-  integrity sha512-+iXhW3LuDQsno8dOIrCIT/CBjeBWuP7PXe8w9shnj9Lebny/Gx1ZjVBYwexLz36Ri2jKuXMNpV6CYNh8lHHgrQ==
+fsevents@~2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
+  integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -466,9 +464,9 @@ glob-all@3.1.0:
     yargs "~1.2.6"
 
 glob-parent@~5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
-  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
+  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
 
@@ -484,19 +482,7 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.5:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
-  integrity sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.1:
+glob@^7.0.5, glob@^7.1.1:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -536,9 +522,9 @@ he@1.2.0:
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hosted-git-info@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
-  integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
+  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -724,27 +710,34 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
 minimist@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
   integrity sha1-md9lelJXTCHJBXSX33QnkLK0wN4=
 
-mkdirp@0.5.1, mkdirp@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+mkdirp@0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.4.tgz#fd01504a6797ec5c9be81ff43d204961ed64a512"
+  integrity sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==
   dependencies:
-    minimist "0.0.8"
+    minimist "^1.2.5"
+
+mkdirp@^0.5.1:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+  dependencies:
+    minimist "^1.2.5"
 
 mocha@^6.2.1:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-6.2.2.tgz#5d8987e28940caf8957a7d7664b910dc5b2fea20"
-  integrity sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-6.2.3.tgz#e648432181d8b99393410212664450a4c1e31912"
+  integrity sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==
   dependencies:
     ansi-colors "3.2.3"
     browser-stdout "1.3.1"
@@ -758,7 +751,7 @@ mocha@^6.2.1:
     js-yaml "3.13.1"
     log-symbols "2.2.0"
     minimatch "3.0.4"
-    mkdirp "0.5.1"
+    mkdirp "0.5.4"
     ms "2.1.1"
     node-environment-flags "1.0.5"
     object.assign "4.1.0"
@@ -766,14 +759,9 @@ mocha@^6.2.1:
     supports-color "6.0.0"
     which "1.3.1"
     wide-align "1.1.3"
-    yargs "13.3.0"
-    yargs-parser "13.1.1"
+    yargs "13.3.2"
+    yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
-
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 ms@2.1.1:
   version "2.1.1"
@@ -895,10 +883,10 @@ pathval@^1.1.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
-picomatch@^2.0.4:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
-  integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
+picomatch@^2.0.4, picomatch@^2.0.7:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -917,12 +905,12 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-readdirp@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.1.3.tgz#d6e011ed5b9240a92f08651eeb40f7942ceb6cc1"
-  integrity sha512-ZOsfTGkjO2kqeR5Mzr5RYDbTGYneSkdNKX2fOX2P5jF7vMrd/GNnIAUtDldeHHumHUCQ3V05YfWUdxMPAsRu9Q==
+readdirp@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.3.0.tgz#984458d13a1e42e2e9f5841b129e162f369aff17"
+  integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
   dependencies:
-    picomatch "^2.0.4"
+    picomatch "^2.0.7"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -1059,21 +1047,39 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string.prototype.trimleft@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz#9bdb8ac6abd6d602b17a4ed321870d2f8dcefc74"
-  integrity sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==
+string.prototype.trimend@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz#ee497fd29768646d84be2c9b819e292439614373"
+  integrity sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==
   dependencies:
     define-properties "^1.1.3"
-    function-bind "^1.1.1"
+    es-abstract "^1.17.5"
+
+string.prototype.trimleft@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz#4408aa2e5d6ddd0c9a80739b087fbc067c03b3cc"
+  integrity sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+    string.prototype.trimstart "^1.0.0"
 
 string.prototype.trimright@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz#440314b15996c866ce8a0341894d45186200c5d9"
-  integrity sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz#c76f1cef30f21bbad8afeb8db1511496cfb0f2a3"
+  integrity sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==
   dependencies:
     define-properties "^1.1.3"
-    function-bind "^1.1.1"
+    es-abstract "^1.17.5"
+    string.prototype.trimend "^1.0.0"
+
+string.prototype.trimstart@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz#afe596a7ce9de905496919406c9734845f01a2f2"
+  integrity sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
 
 strip-ansi@^4.0.0:
   version "4.0.0"
@@ -1123,9 +1129,9 @@ to-regex-range@^5.0.1:
     is-number "^7.0.0"
 
 ts-node@^8.4.1:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.6.2.tgz#7419a01391a818fbafa6f826a33c1a13e9464e35"
-  integrity sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.8.2.tgz#0b39e690bee39ea5111513a9d2bcdc0bc121755f"
+  integrity sha512-duVj6BpSpUpD/oM4MfhO98ozgkp3Gt9qIp3jGxwU2DFvl/3IRaEAvbLa8G60uS7C77457e/m5TMowjedeRxI1Q==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
@@ -1242,15 +1248,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yargs-parser@13.1.1:
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
-  integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^13.1.1, yargs-parser@^13.1.2:
+yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
@@ -1267,23 +1265,7 @@ yargs-unparser@1.6.0:
     lodash "^4.17.15"
     yargs "^13.3.0"
 
-yargs@13.3.0:
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
-  integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
-  dependencies:
-    cliui "^5.0.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^13.1.1"
-
-yargs@^13.3.0:
+yargs@13.3.2, yargs@^13.3.0:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
   integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==


### PR DESCRIPTION
This upgrades the dependencies since there's a minimist security alert active at the moment.

Note: This won't completely resolve the `minimist` security alert, as we depend on `nlf` as a dev dependency which, relies on a specific version of `glob-all`, which in turn relies on an old `yargs` package which then relies on `minimist@0.1.0`. Unfortunately we're already using the latest version of `nlf`, as such I've logged an issue with them to fix their deps: https://github.com/iandotkelly/nlf/issues/63