### PR TITLE
TINY-5882: Fixed incorrectly resolving imports from other rollup plugins

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+# [4.3.2] - 2020-10-02
+
+### Fixed
+- Fixed incorrectly resolving imports from other rollup plugins.
+
 # [4.3.0] - 2020-07-28
 
 ### Added

--- a/src/main/ts/fs/Resolve.ts
+++ b/src/main/ts/fs/Resolve.ts
@@ -107,7 +107,10 @@ const runMappers = (importer: string, mappers: Mappers) => (resolvedImportee: st
 };
 
 const resolveId = (fs: FileSystem, prefixes: Prefixes, mappers: Mappers, forceFlat: boolean) => (importee: string, importer: string) => {
-  if (/\0/.test(importee) || !importer) { return null; }
+  // ignore IDs with null character, these belong to other plugins
+  if (/\0/.test(importee) || !importer || /\0/.test(importer)) {
+    return null;
+  }
 
   if (matchesPrefix(prefixes, importee)) {
     return resolvePrefix(prefixes, importee, importer);

--- a/src/test/ts/fs/Resolve.spec.ts
+++ b/src/test/ts/fs/Resolve.spec.ts
@@ -80,4 +80,12 @@ describe('Resolve', () => {
     const resolvedPath = await resolver('@ephox/katamari', '/project/src/Main.js');
     expect(resolvedPath).to.equal('/prefix/project/node_modules/@ephox/katamari/Main.js');
   });
+
+  it('should not resolve rollup plugin imports', async () => {
+    const resolver = resolveId(mockFs, {}, [], false);
+
+    const resolvedPath = await resolver('/project/src/Main.js', '\0/project/src/Main.js?commonjs-proxy');
+    // tslint:disable-next-line:no-unused-expression
+    expect(resolvedPath).to.be.null;
+  });
 });


### PR DESCRIPTION
This was something I discovered when trying to create the exports plugin, as we need to use the rollup commonjs plugin to load third-party libraries and this was causing the bundling to fail with this error:
```
Warning: The argument 'path' must be a string or Uint8Array without null bytes. Received '/path/\u0000/path/node_modules/es6-promise/dist' Use --force to continue.
```
It turns out the importer is something like what's used in the test case I've added.