### PR TITLE
TINY-8245: Added support for parsing newer ECMAScript versions up to ES2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 4.5.0 - 2021-11-24
+
+### Added
+- Added support for parsing up to ES2021 syntax.
+
 ## 4.4.0 - 2020-06-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/swag",
-  "version": "4.4.1-rc",
+  "version": "4.5.0-rc",
   "description": "A collection of tools for rollup/webpack",
   "private": false,
   "repository": {

--- a/src/main/ts/ast/js/Parser.ts
+++ b/src/main/ts/ast/js/Parser.ts
@@ -3,7 +3,7 @@ import * as estree from 'estree';
 
 const parse = (code: string): estree.Program => {
   const program = acorn.parse(code, {
-    ecmaVersion: 8,
+    ecmaVersion: 2021,
     sourceType: 'module',
     preserveParens: false,
     ranges: false

--- a/src/test/ts/ast/js/ParserSerializer.spec.ts
+++ b/src/test/ts/ast/js/ParserSerializer.spec.ts
@@ -14,4 +14,16 @@ describe('Parser/Serializer', () => {
       'var x = { x: \'a\\uFEFF\\uFEFF\' };'
     ].join('\n'));
   });
+
+  it('should handle optional chaining when parsing/serializing', () => {
+    const ast = parse([
+      'const x = {};',
+      'let a = x?.b;'
+    ].join('\n'));
+
+    expect(serialize(ast)).to.equal([
+      'const x = {};',
+      'let a = x?.b;'
+    ].join('\n'));
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-8245, TINY-8253

Description of Changes:

As we're moving to use ES2020 I ran into an issue as the swag parser was only configured to handle up to ES2017 syntax (the specific issue was optional chainging). So this just updates it to handle up to ES2021 (it's one version newer than what we need to give some wiggle room).

Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] Tests have been added (if applicable)

Before merging:
* [x] Review comments resolved
