### PR TITLE
TINY-8756: Updated GitHub CODEOWNERS and PR template files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tinymce/editor-platform-team @spocke
+* @tinymce/tinymce-reviewers @spocke

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,3 @@ Pre-checks:
 * [ ] Changelog entry added
 * [ ] package.json version bumped (if first change of new major/minor)
 * [ ] Tests have been added (if applicable)
-
-Before merging:
-* [ ] Review comments resolved


### PR DESCRIPTION
Related Ticket: TINY-8756

Description of Changes:
* Update the codeowners to use the new reviewers group
* Remove the comments resolved checkbox from the PR template as we'll use the branch protection instead

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~package.json version bumped (if first change of new major/minor)~
* [x] ~Tests have been added (if applicable)~

Before merging:
* [ ] Review comments resolved
